### PR TITLE
feat: OneKey account change

### DIFF
--- a/.changeset/fast-radios-march.md
+++ b/.changeset/fast-radios-march.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+Remove OneKey accountsChanged event

--- a/.changeset/unlucky-seas-listen.md
+++ b/.changeset/unlucky-seas-listen.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+chore: bump btc-staking-ts to canary 13

--- a/src/core/wallets/btc/okx/provider.ts
+++ b/src/core/wallets/btc/okx/provider.ts
@@ -161,7 +161,7 @@ export class OKXProvider implements IBTCProvider {
   off = (eventName: string, callBack: () => void) => {
     if (!this.walletInfo) throw new Error("OKX Wallet not connected");
 
-    // subscribe to account change event
+    // unsubscribe from account change event
     if (eventName === "accountChanged") {
       return this.provider.off(eventName, callBack);
     }

--- a/src/core/wallets/btc/onekey/provider.ts
+++ b/src/core/wallets/btc/onekey/provider.ts
@@ -146,21 +146,19 @@ export class OneKeyProvider implements IBTCProvider {
   on = (eventName: string, callBack: () => void) => {
     if (!this.walletInfo) throw new Error("OneKey Wallet not connected");
 
-    // subscribe to account change event: `accountChanged` -> `accountsChanged`
+    // subscribe to account change event
     if (eventName === "accountChanged") {
-      return this.provider.on("accountsChanged", callBack);
+      return this.provider.on(eventName, callBack);
     }
-    return this.provider.on(eventName, callBack);
   };
 
   off = (eventName: string, callBack: () => void) => {
     if (!this.walletInfo) throw new Error("OneKey Wallet not connected");
 
-    // unsubscribe to account change event
+    // unsubscribe from account change event
     if (eventName === "accountChanged") {
-      return this.provider.off("accountsChanged", callBack);
+      return this.provider.off(eventName, callBack);
     }
-    return this.provider.off(eventName, callBack);
   };
 
   getWalletProviderName = async (): Promise<string> => {


### PR DESCRIPTION
Remove `accountsChanged ` event from OneKey. Only `accountChanged` is used

Partly closes https://github.com/babylonlabs-io/babylon-wallet-connector/issues/188