### PR TITLE
feat: Unisat - accountsChanged removeListenet

### DIFF
--- a/.changeset/famous-buttons-protect.md
+++ b/.changeset/famous-buttons-protect.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+Unisat removeListener

--- a/src/core/wallets/btc/unisat/provider.ts
+++ b/src/core/wallets/btc/unisat/provider.ts
@@ -228,17 +228,15 @@ export class UnisatProvider implements IBTCProvider {
     if (eventName === "accountChanged") {
       return this.provider.on("accountsChanged", callBack);
     }
-    return this.provider.on(eventName, callBack);
   };
 
   off = (eventName: string, callBack: () => void) => {
     if (!this.walletInfo) throw new Error("Unisat Wallet not connected");
 
-    // unsubscribe to account change event
+    // unsubscribe from account change event: `accountChanged` -> `accountsChanged`
     if (eventName === "accountChanged") {
-      return this.provider.off("accountsChanged", callBack);
+      return this.provider.removeListener("accountsChanged", callBack);
     }
-    return this.provider.off(eventName, callBack);
   };
 
   getWalletProviderName = async (): Promise<string> => {


### PR DESCRIPTION
Unisat uses `removeListener` instead of `off`
Partly closes https://github.com/babylonlabs-io/babylon-wallet-connector/issues/188